### PR TITLE
fix(modules/classic-composer): use correct path to shopware install.sh

### DIFF
--- a/modules/classic-composer/build.sh
+++ b/modules/classic-composer/build.sh
@@ -16,4 +16,7 @@ echo "SHOP_URL=\"http://$SHOPWARE_PROJECT.dev.localhost\"" >> "$SHOPWARE_FOLDER/
 echo 'IMPORT_DEMODATA=y' >> "$SHOPWARE_FOLDER/.env"
 
 bash -c "composer install"
-bash -c "/var/www/html/${SHOPWARE_PROJECT}/app/install.sh"
+
+NEW_INSTALLER_PATH="/var/www/html/${SHOPWARE_PROJECT}/app/bin/install.sh"
+OLD_INSTALLER_PATH="/var/www/html/${SHOPWARE_PROJECT}/app/install.sh"
+bash -c "if [ -x \"$NEW_INSTALLER_PATH\" ]; then bash \"$NEW_INSTALLER_PATH\"; else bash \"$OLD_INSTALLER_PATH\"; fi"


### PR DESCRIPTION
First: Great project! This saves a lot of time for me, thank you!


## Issue
I'm using the shopware-composer project. When running `swdc build [FOLDER]` I get the following error:
`bash: /var/www/html/sw_cd_testing/app/install.sh: No such file or directory`

<details>
<summary>Show full build output</summary>

```
rafael@RK-Lap ~ swdc build sw_cd_testing

Loading composer repositories with package information
Installing dependencies (including require-dev) from lock file
Nothing to install or update
Generating optimized autoload files
Warning: Ambiguous class resolution, "Doctrine\ORM\Persisters\Entity\BasicEntityPersister" was found in both "/var/www/html/sw_cd_testing/vendor/shopware/shopware/engine/Library/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php" and "/var/www/html/sw_cd_testing/vendor/doctrine/orm/lib/Doctrine/ORM/Persisters/Entity/BasicEntityPersister.php", the first will be used.
Warning: Ambiguous class resolution, "Doctrine\Common\Proxy\AbstractProxyFactory" was found in both "/var/www/html/sw_cd_testing/vendor/shopware/shopware/engine/Library/Doctrine/Common/Proxy/AbstractProxyFactory.php" and "/var/www/html/sw_cd_testing/vendor/doctrine/common/lib/Doctrine/Common/Proxy/AbstractProxyFactory.php", the first will be used.
ocramius/package-versions:  Generating version class...
ocramius/package-versions: ...done generating version class
> ./app/bin/post-install.sh
Creating symlinks in /var/www/html/sw_cd_testing/app/bin
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/mpdf/mpdf/ttfonts
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/protobuf/src
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/protobuf/java
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/protobuf/objectivecs
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/protobuf/csharp
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/protobuf/python
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/protobuf/ruby
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/protobuf/js
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/protobuf/javanano
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/protobuf/php/ext
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/protobuf/php/tests
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/cloud/tests
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/cloud/dev
+ rm -rf -- /var/www/html/sw_cd_testing/app/bin/../../vendor/google/cloud/docs
+ set +eux
  ____  _
 / ___|| |__   ___  _ ____      ____ _ _ __ ___
 \___ \| '_ \ / _ \| '_ \ \ /\ / / _` | '__/ _ \
  ___) | | | | (_) | |_) \ V  V / (_| | | |  __/
 |____/|_| |_|\___/| .__/ \_/\_/ \__,_|_|  \___|
                   |_|


Loading configuration settings from .env file
Updating Shopware install, please wait...
Creating symlinks in /var/www/html/sw_cd_testing/app/bin
 WARNING! SQLSTATE[42S02]: Base table or view not found: 1146 Table 'sw_cd_testing.s_core_plugins' doesn't exist in /var/www/html/sw_cd_testing/vendor/shopware/shopware/engine/Shopware/Bundle/PluginInstallerBundle/Service/PluginInitializer.php 
Current MigrationNumber: 0
Found 576 migrations to apply
Apply MigrationNumber: 101 - add-extended-editor-field

In Manager.php line 251:
                                                                               
  Could not apply migration (Migrations_Migration101). Error: SQLSTATE[42S02]  
  : Base table or view not found: 1146 Table 'sw_cd_testing.s_core_auth' does  
  n't exist                                                                    
                                                                               

sw:migrations:migrate [--mode MODE]

bash: /var/www/html/sw_cd_testing/app/install.sh: No such file or directory
```
</details>

## Reason
[This shopware-composer commit](https://github.com/shopware/composer-project/commit/df591b14c8b955142e6fe874d19dad5724a88f13#diff-09dd9a438196c1151e67cfcce0bd6c48) moved the file from `/app/install.sh` to `/app/bin/install.sh`

## Fix
With this PR the the build file will first check if the new file exists and is executable.
If so, the new file is executed. Otherwise the old file is used.