### PR TITLE
Add console command as a shortcut for the symfony console

### DIFF
--- a/modules/base/console.help
+++ b/modules/base/console.help
@@ -1,0 +1,1 @@
+Executes the symfony console for the given project

--- a/modules/base/console.sh
+++ b/modules/base/console.sh
@@ -1,0 +1,13 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+SHOPWARE_PROJECT=$2
+shift 2
+
+docker-compose -f "$DOCKER_COMPOSE_FILE" run \
+  --rm \
+  --no-deps \
+  -u "$(id -u):$(id -g)" \
+  --entrypoint="bin/console" \
+  -w "/var/www/html/$SHOPWARE_PROJECT" \
+  cli "$@"

--- a/modules/base/console.usage
+++ b/modules/base/console.usage
@@ -1,0 +1,10 @@
+Executes the symfony console for the given project
+
+Usage:
+  console project_dir [command...]
+
+Examples:
+
+  swdc console shopware-5 sw:cache:clear
+
+  swdc console sw6 plugin:refresh && swdc console sw6 plugin:install -c --activate MyAwesomePlugin

--- a/modules/base/shell.sh
+++ b/modules/base/shell.sh
@@ -1,3 +1,8 @@
 #!/usr/bin/env bash
 
-docker-compose -f ${DOCKER_COMPOSE_FILE} exec -e COLUMNS="`tput cols`" -e LINES="`tput lines`" -e SHELL=bash cli bash
+if [[ -z "$2" ]]; then
+  docker-compose -f ${DOCKER_COMPOSE_FILE} exec -e COLUMNS -e LINES -e SHELL=bash cli bash
+else
+  shift
+  docker-compose -f ${DOCKER_COMPOSE_FILE} exec -e COLUMNS -e LINES -e SHELL=bash cli "$@"
+fi

--- a/modules/base/shell.usage
+++ b/modules/base/shell.usage
@@ -1,1 +1,13 @@
 Joins into the cli container as normal user
+If an argument is given to the command, it will be executed inside the cli-container
+using the bash shell.
+
+Usage:
+  shell [command...]
+
+Examples:
+
+  swdc shell
+    # Creates an interactive bash shell-session inside the cli container
+  swdc shell composer install -d shopware
+    # Executes a composer install inside the "shopware" project directory

--- a/modules/classic/apply.help
+++ b/modules/classic/apply.help
@@ -1,1 +1,1 @@
-Applys a database fixture
+Applies a database fixture


### PR DESCRIPTION
I added a non-interactive mode for the shell command and symfony console here.
This may be useful, if one doesn't want to keep a dedicated terminal running for the interactive shell session.