### PR TITLE
Wait for the database server before finishing startup

### DIFF
--- a/modules/base/up.sh
+++ b/modules/base/up.sh
@@ -27,6 +27,7 @@ echo "      - ${HTTPS_PORT}:443" >> ${DOCKER_COMPOSE_FILE}
 
 create_nginx
 create_mysql
+create_start_mysql
 create_cli
 
 # Build alias for cli
@@ -61,4 +62,5 @@ if [[ ${CACHE_VOLUMES} == "true" ]]; then
     create_caching
 fi
 
+docker-compose -f ${DOCKER_COMPOSE_FILE} run --rm start_mysql
 docker-compose -f ${DOCKER_COMPOSE_FILE} up -d --remove-orphans

--- a/modules/defaults/base-up.sh
+++ b/modules/defaults/base-up.sh
@@ -62,6 +62,26 @@ function create_mysql() {
     fi
 }
 
+function create_start_mysql() {
+  cat <<EOF >> ${DOCKER_COMPOSE_FILE}
+  start_mysql:
+    image: busybox:latest
+    entrypoint:
+      - sh
+    command: >
+      -c "
+        while !(nc -z mysql 3306)
+        do
+          echo -n '.'
+          sleep 1
+        done;
+        echo 'database ready!'
+      "
+    depends_on:
+      - mysql
+EOF
+}
+
 function create_cli () {
     echo "  cli:" >> ${DOCKER_COMPOSE_FILE}
     echo "    image: shyim/shopware-cli:php${PHP_VERSION}" >> ${DOCKER_COMPOSE_FILE}


### PR DESCRIPTION
This change enables running commands like `swdc up && swdc build shopware` without errors due to the database server not being reachable.