### PR TITLE
Create $HOME/.config/swdc if it not exists at an earlier point

### DIFF
--- a/swdc
+++ b/swdc
@@ -15,11 +15,13 @@ export REALDIR=$(realpath ${DIR})
 source "${DIR}/functions.sh"
 
 if [[ ! -d "${HOME}/.config/swdc" ]]; then
-  if [[ -f "${HOME}/.swdc_env" ]]; then
-    mv "${HOME}/.swdc_env" "${HOME}/.config/swdc/env"
-  else
-    cp "${DIR}/.env.dist" "${HOME}/.config/swdc/env"
-  fi
+  mkdir -p "${HOME}/.config/swdc"
+fi
+
+if [[ -f "${HOME}/.swdc_env" ]]; then
+  mv "${HOME}/.swdc_env" "${HOME}/.config/swdc/env"
+else
+  cp "${DIR}/.env.dist" "${HOME}/.config/swdc/env"
 fi
 
 source "${DIR}/.env.dist"


### PR DESCRIPTION
This fix will create the `.config/swdc` folder at an earlier point
so that copying the `.env.dist` file will work properly on first run.

Signed-off-by: Alexander Kluth <alexander.kluth@pixolith.de>