### PR TITLE
Remove ^ character

### DIFF
--- a/README.md
+++ b/README.md
@@ -111,6 +111,9 @@ This setup works for Shopware 5 and Shopware 6
 
 I dont't develop on Windows or Mac. Try it out by own
 
+### macOS
+It is working on macOS if you have `realpath` available. I tested with: [realpath for OS X](https://github.com/harto/realpath-osx)
+
 ## What are the passwords?
 
 ### SMTP

--- a/functions.sh
+++ b/functions.sh
@@ -55,7 +55,7 @@ function trim_whitespace() {
 function get_image()
 {
     folder=$1
-    var="VHOST_${folder^^}_IMAGE"
+    var="VHOST_${folder}_IMAGE"
     var="${var//-/_}"
     val=${!var}
     SUFFIX=""
@@ -79,7 +79,7 @@ function get_image()
 function get_hosts()
 {
     folder=$1
-    var="VHOST_${folder^^}_HOSTS"
+    var="VHOST_${folder}_HOSTS"
     var="${var//-/_}"
     val=${!var}
 
@@ -126,7 +126,7 @@ function get_url()
 function get_cert_name()
 {
     folder=$1
-    var="VHOST_${folder^^}_CERT_NAME"
+    var="VHOST_${folder}_CERT_NAME"
     var="${var//-/_}"
     val=${!var}
 


### PR DESCRIPTION
Seems like the name is not set correctly with that character.

With that change it works on macOS Catalina.