### PR TITLE
use clean-install for admin-init and storefront-init

### DIFF
--- a/modules/platform/admin-init.sh
+++ b/modules/platform/admin-init.sh
@@ -3,7 +3,7 @@ checkParameter
 cd "/var/www/html/${SHOPWARE_PROJECT}"
 
 if [[ -e vendor/shopware/platform ]]; then
-    npm install --prefix vendor/shopware/platform/src/Administration/Resources/app/administration/
+    npm --prefix vendor/shopware/platform/src/Administration/Resources/app/administration/ clean-install
 else
-    npm install --prefix vendor/shopware/administration/Resources/app/administration/
+    npm --prefix vendor/shopware/administration/Resources/app/administration/ clean-install
 fi

--- a/modules/platform/storefront-init.sh
+++ b/modules/platform/storefront-init.sh
@@ -9,7 +9,7 @@ cd ${PROJECT_ROOT}
 bin/console bundle:dump
 
 if [[ -e vendor/shopware/platform ]]; then
-    npm --prefix vendor/shopware/platform/src/Storefront/Resources/app/storefront/ install
+    npm --prefix vendor/shopware/platform/src/Storefront/Resources/app/storefront/ clean-install
 else
-    npm --prefix vendor/shopware/storefront/Resources/app/storefront/ install
+    npm --prefix vendor/shopware/storefront/Resources/app/storefront/ clean-install
 fi


### PR DESCRIPTION
this makes it much easier to update local shopware instances