### PR TITLE
Automatic Dockerfile Image Updater

### DIFF
--- a/images/proxy/Dockerfile
+++ b/images/proxy/Dockerfile
@@ -1,4 +1,4 @@
-FROM jwilder/nginx-proxy
+FROM jwilder/nginx-proxy:v0.9.0
 
 COPY unrestricted_client_body_size.conf /etc/nginx/conf.d/unrestricted_client_body_size.conf
 COPY proxy.conf /etc/nginx/proxy.conf


### PR DESCRIPTION
`jwilder/nginx-proxy` changed recently. This pull request ensures you're using the latest version of the image and changes `jwilder/nginx-proxy` to the latest tag: `v0.9.0`

New base image: `jwilder/nginx-proxy:v0.9.0`