### PR TITLE
Make readlink in ./swdc recursive

### DIFF
--- a/swdc
+++ b/swdc
@@ -6,7 +6,7 @@ export DOCKER_COMPOSE_FILE="/tmp/swdc-docker-compose.yml"
 FILE="$0"
 
 if [[ -L "$0" ]]; then
-  FILE="$(readlink "${0}")"
+  FILE="$(readlink -f "${0}")"
 fi
 
 DIR="$(dirname "${FILE}")"


### PR DESCRIPTION
This fix allows users to have arbitrarily long symbolic link chains to
the swdc script, no longer forcing users to link directly to /usr/local/bin/swdc.

This was needed in my case to get swdc to build through nix.