### PR TITLE
Flag that helps with Binary data. The end file will be slightly bigger.

### DIFF
--- a/modules/base/snap.sh
+++ b/modules/base/snap.sh
@@ -18,4 +18,4 @@ fi
 
 checkParameter
 
-compose exec -T $CONTAINER mysqldump -uroot -p"${MYSQL_ROOT_PASSWORD}" "${SHOPWARE_PROJECT}" >"${SNAP_DIR}/${SHOPWARE_PROJECT}${SNAP_SUFFIX}.sql"
+compose exec -T $CONTAINER mysqldump -uroot -p"${MYSQL_ROOT_PASSWORD}" --hex-blob "${SHOPWARE_PROJECT}" >"${SNAP_DIR}/${SHOPWARE_PROJECT}${SNAP_SUFFIX}.sql"


### PR DESCRIPTION
Hy, 

i had some problems with swdc rsnap <project>. 
It had some errors with the import / writing of some binary data (in the order table). 
Creating a mysqldump with the --hex-blob helped in the import phase.  The dump itself will be slightly bigger.