### PR TITLE
Add explicit console port to minio config

### DIFF
--- a/modules/classic/fix-config.php
+++ b/modules/classic/fix-config.php
@@ -82,7 +82,7 @@ if (isset($_SERVER['argv'][2])) {
 				'adapters' => [
 					's3' => [
 						'type' => 's3',
-						'mediaUrl' => 'http://localhost:9000/shopware',
+						'mediaUrl' => 'http://localhost:9010/shopware',
 						'bucket' => 'shopware',
 						'use_path_style_endpoint' => true,
 						'endpoint' => 'http://minio:9000',

--- a/modules/defaults/base-up.sh
+++ b/modules/defaults/base-up.sh
@@ -230,12 +230,13 @@ function create_minio() {
     echo "  minio:"
     echo "    image: minio/minio"
     echo "    env_file: ${REALDIR}/docker.env"
-    echo "    command: server /data"
+    echo "    command: server /data --console-address=':9015'"
     echo "    ports:"
-    echo "      - 9000:9000"
+    echo "      - 9010:9000"
+    echo "      - 9015:9015"
     echo "    environment:"
     echo "      VIRTUAL_HOST: s3.${DEFAULT_SERVICES_DOMAIN}"
-    echo "      VIRTUAL_PORT: 9000"
+    echo "      VIRTUAL_PORT: 9015"
   } >>"${DOCKER_COMPOSE_FILE}"
 }
 


### PR DESCRIPTION
This allows minio to run again, tested with the virtual service domain `s3.dev.service` as well. I've switched the host passthrough-port from `9000` to `9010` to prevent a collision with XDebug.