### PR TITLE
Add calendar extension to images

### DIFF
--- a/images/apache/Dockerfile.twig
+++ b/images/apache/Dockerfile.twig
@@ -28,7 +28,7 @@ RUN set -x && \
       shadow \
       gnu-libiconv \
       socat && \
-    install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 gmp soap zip gmp redis imagick {% if phpVersionNumeric >= 74 %} ffi excimer {% endif %} {% if production %} opcache {% endif %} {% if xdebug %} xdebug{% if phpVersionNumeric >= 71 and xdebug == 2 %}-2.9.8{% endif %}{% endif %} && \
+    install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 gmp soap zip gmp redis imagick calendar {% if phpVersionNumeric >= 74 %} ffi excimer {% endif %} {% if production %} opcache {% endif %} {% if xdebug %} xdebug{% if phpVersionNumeric >= 71 and xdebug == 2 %}-2.9.8{% endif %}{% endif %} && \
     ln -s /usr/local/bin/php /usr/bin/php && \
     rm -rf /tmp/* && \
     chown -R www-data:www-data /var/www && \

--- a/images/cli/Dockerfile.twig
+++ b/images/cli/Dockerfile.twig
@@ -28,7 +28,7 @@ RUN set -x && \
       gnu-libiconv \
       jq \
       make && \
-    install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 gmp soap zip gmp pcntl posix redis pcov imagick xsl{% if phpVersionNumeric >= 74 %} ffi excimer {% endif %} {% if production %} opcache {% endif %} {% if xdebug %} xdebug{% if phpVersionNumeric >= 71 and xdebug == 2 %}-2.9.8{% endif %} {% endif %} && \
+    install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 gmp soap zip gmp pcntl posix redis pcov imagick xsl calendar{% if phpVersionNumeric >= 74 %} ffi excimer {% endif %} {% if production %} opcache {% endif %} {% if xdebug %} xdebug{% if phpVersionNumeric >= 71 and xdebug == 2 %}-2.9.8{% endif %} {% endif %} && \
     rm -rf /tmp/* && \
     useradd dev && \
     mkdir /home/dev && \

--- a/images/nginx/Dockerfile.twig
+++ b/images/nginx/Dockerfile.twig
@@ -26,7 +26,7 @@ RUN set -x && \
       shadow \
       gnu-libiconv \
       socat && \
-    install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 gmp soap zip opcache redis {% if phpVersionNumeric < 81 %}imagick {% endif%} {% if phpVersionNumeric >= 74 %} ffi excimer {% endif %} {% if xdebug %} xdebug{% if phpVersionNumeric >= 71 and xdebug == 2 %}-2.9.8{% endif %}{% endif %} && \
+    install-php-extensions bcmath gd intl mysqli pdo_mysql sockets bz2 gmp soap zip opcache redis calendar {% if phpVersionNumeric < 81 %}imagick {% endif%} {% if phpVersionNumeric >= 74 %} ffi excimer {% endif %} {% if xdebug %} xdebug{% if phpVersionNumeric >= 71 and xdebug == 2 %}-2.9.8{% endif %}{% endif %} && \
     ln -s /usr/local/bin/php /usr/bin/php && \
     ln -sf /dev/stdout /var/log/nginx/access.log && \
     ln -sf /dev/stderr /var/log/nginx/error.log && \


### PR DESCRIPTION
This extension is used in the core (with a fallback in case it's not installed) but hasn't been required [until now](https://github.com/shopware/shopware/commit/7cbff71600e6f3c95318a727a442e732fe7c5cb0#diff-d2ab9925cad7eac58e0ff4cc0d251a937ecf49e4b6bf57f8b95aab76648a9d34R20). I've lost track on how exactly the images get built at the moment 😅 It seems you're currently using the same Dockerfiles for SW5/6 and I can't find any logic regarding Shopware versions in there. In case this change should only be applied to the SW5 images, I'll try to update my PR accordingly.