### PR TITLE
Remove DEFINER from sql dump

### DIFF
--- a/modules/base/snap.sh
+++ b/modules/base/snap.sh
@@ -18,4 +18,4 @@ fi
 
 checkParameter
 
-compose exec -T $CONTAINER mysqldump -uroot -p"${MYSQL_ROOT_PASSWORD}" --hex-blob "${SHOPWARE_PROJECT}" >"${SNAP_DIR}/${SHOPWARE_PROJECT}${SNAP_SUFFIX}.sql"
+compose exec -T $CONTAINER mysqldump -uroot -p"${MYSQL_ROOT_PASSWORD}" --hex-blob "${SHOPWARE_PROJECT}" | LANG=C LC_CTYPE=C LC_ALL=C sed -e 's/DEFINER[ ]*=[ ]*[^*]*\*/\*/' >"${SNAP_DIR}/${SHOPWARE_PROJECT}${SNAP_SUFFIX}.sql"


### PR DESCRIPTION
I could not find a way to remove the DEFINER during import, but while creating a dump, we can remove the DEFINER from the dump. Maybe this helps in the issue #109 