### PR TITLE
feat: add swdcignore

### DIFF
--- a/functions.sh
+++ b/functions.sh
@@ -148,10 +148,13 @@ function get_document_root() {
 }
 
 function get_serve_folders() {
+  ignorefile="${CODE_DIRECTORY}/.swdcignore"
   for d in "${CODE_DIRECTORY}"/*; do
     if [[ -d "$d" ]]; then
       if [ -f "$d/public/index.php" ] || [ -f "$d/shopware.php" ] || [ -f "$d/.swdc/service.yml" ]; then
-        basename "$d"
+        if [[ ! -f "$ignorefile"  ]] || $(basename "$d" | grep -qvf "$ignorefile"); then
+          basename "$d"
+        fi
       fi
     fi
   done


### PR DESCRIPTION
I'd like swdc to share its code directory with other projects that don't need a shopware setup.
For that, I've implemented an ignore file; if a `$codeDir/.swdcignore` exists, it looks if a directory
matches one of the regexes given in the ignore file and then skips building containers for it.