### PR TITLE
fix: do not rebuild on each test execution

### DIFF
--- a/modules/classic/build.sh
+++ b/modules/classic/build.sh
@@ -82,3 +82,5 @@ fixHooks
 if [[ $patchConfig == 1 ]]; then
   php "${DIR}"/modules/classic/fix-config.php "$SHOPWARE_FOLDER/config.php"
 fi
+
+mysqldump -h "$mysqlHost" -u root -p"${MYSQL_ROOT_PASSWORD}" "$SHOPWARE_PROJECT" > "build_backup.sql"

--- a/modules/classic/test.sh
+++ b/modules/classic/test.sh
@@ -1,10 +1,11 @@
 #!/usr/bin/env bash
 
+mysqlHost="mysql"
 checkParameter
 
 cd /var/www/html/"${SHOPWARE_PROJECT}" || exit 1
 
-$0 build "$SHOPWARE_PROJECT"
+mysql -h "${mysqlHost}" -u root -p"${MYSQL_ROOT_PASSWORD}"  "$SHOPWARE_PROJECT" < "build_backup.sql"
 
 vendor/bin/phpunit tests/Unit/ --config tests/phpunit_unit.xml.dist "${@:3}"
 


### PR DESCRIPTION
Current implementation will build everything new in Shopware classic without any real reason to do so. 
With this implementation, it will use the dump that have been created by the last build and restores it on test.
Should immensely speed up testing.