### PR TITLE
Dump features when building storefront

### DIFF
--- a/modules/platform/storefront-build.sh
+++ b/modules/platform/storefront-build.sh
@@ -11,6 +11,7 @@ setup_node_version
 PLATFORM_PATH=$(platform_component Storefront)
 
 bin/console bundle:dump
+bin/console feature:dump
 
 npm --prefix "${PLATFORM_PATH}/Resources/app/storefront/" run production
 


### PR DESCRIPTION
The feature dump may be outdated when running webpack config build. This can lead to a broken Storefront when activating the major flag.

Add `feature:dump` to `storefront-build.sh` script.